### PR TITLE
updated troposphere to version 3.0.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -355,7 +355,7 @@ description = "AWS CloudFormation creation library"
 name = "troposphere"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.7.1"
+version = "3.0.2"
 
 [package.dependencies]
 cfn_flip = ">=1.0.2"
@@ -641,7 +641,7 @@ tqdm = [
     {file = "tqdm-4.61.1.tar.gz", hash = "sha256:24be966933e942be5f074c29755a95b315c69a91f839a29139bf26ffffe2d3fd"},
 ]
 troposphere = [
-    {file = "troposphere-2.7.1.tar.gz", hash = "sha256:ea2e5f2f82c224eaa1414a008b1939aae124c3e3e1dd993301968f155b333bd7"},
+    {file = "troposphere-3.0.2.tar.gz", hash = "sha256:acde51e47294bdb2bce4f0be4320ac12dbd3c6a2783895779ddb94cfdc0badaf"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},


### PR DESCRIPTION
As discussing in issue #1 

This is a minor update that gets the poetry install working again.

